### PR TITLE
Resolve some NU1608 warnings in the EthInclude.csproj

### DIFF
--- a/EthInclude.csproj
+++ b/EthInclude.csproj
@@ -11,10 +11,10 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="MySql.Data" Version="8.0.25" />
-    <PackageReference Include="Nethereum.Geth" Version="3.8.0" />
-    <PackageReference Include="Nethereum.JsonRpc.WebSocketClient" Version="3.8.0" />
-    <PackageReference Include="Nethereum.RPC.Reactive" Version="3.8.0" />
-    <PackageReference Include="Nethereum.Web3" Version="3.8.0" />
+    <PackageReference Include="Nethereum.Geth" Version="4.0.4" />
+    <PackageReference Include="Nethereum.JsonRpc.WebSocketClient" Version="4.0.4" />
+    <PackageReference Include="Nethereum.RPC.Reactive" Version="4.0.4" />
+    <PackageReference Include="Nethereum.Web3" Version="4.0.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
   </ItemGroup>


### PR DESCRIPTION
Hi, I found some NU1608 warnings in the EthInclude.csproj:

`Warning NU1608 Detected package version outside of dependency constraint: Nethereum.Web3 3.8.0 requires Newtonsoft.Json (>= 10.0.3 && < 13.0.0)，but version Newtonsoft.Json 13.0.1 was resolved.`	
`Warning NU1608 Detected package version outside of dependency constraint: Nethereum.RPC.Reactive 3.8.0 requires Newtonsoft.Json (>= 10.0.3 && < 13.0.0)，but version Newtonsoft.Json 13.0.1 was resolved.`	
`Warning NU1608 Detected package version outside of dependency constraint: Nethereum.Geth 3.8.0 requires Newtonsoft.Json (>= 10.0.3 && < 13.0.0)，but version Newtonsoft.Json 13.0.1 was resolved.`	
`Warning NU1608 Detected package version outside of dependency constraint: Nethereum.JsonRpc.WebSocketClient 3.8.0 requires Newtonsoft.Json (>= 10.0.3 && < 13.0.0)，but version Newtonsoft.Json 13.0.1 was resolved.`	
`Warning NU1608 Detected package version outside of dependency constraint: Nethereum.ABI 3.8.0 requires Newtonsoft.Json (>= 10.0.3 && < 13.0.0)，but version Newtonsoft.Json 13.0.1 was resolved.`	
`Warning NU1608 Detected package version outside of dependency constraint: Nethereum.Accounts 3.8.0 requires Newtonsoft.Json (>= 10.0.3 && < 13.0.0)，but version Newtonsoft.Json 13.0.1 was resolved.`	
`Warning NU1608 Detected package version outside of dependency constraint: Nethereum.BlockchainProcessing 3.8.0 requires Newtonsoft.Json (>= 10.0.3 && < 13.0.0)，but version Newtonsoft.Json 13.0.1 was resolved.`	
`Warning NU1608 Detected package version outside of dependency constraint: Nethereum.Contracts 3.8.0 requires Newtonsoft.Json (>= 10.0.3 && < 13.0.0)，but version Newtonsoft.Json 13.0.1 was resolved.`	
`Warning NU1608 Detected package version outside of dependency constraint: Nethereum.Hex 3.8.0 requires Newtonsoft.Json (>= 10.0.3 && < 13.0.0)，but version Newtonsoft.Json 13.0.1 was resolved.`	
`Warning NU1608 Detected package version outside of dependency constraint: Nethereum.JsonRpc.RpcClient 3.8.0 requires Newtonsoft.Json (>= 10.0.3 && < 13.0.0)，but version Newtonsoft.Json 13.0.1 was resolved.`	
`Warning NU1608 Detected package version outside of dependency constraint: Nethereum.KeyStore 3.8.0 requires Newtonsoft.Json (>= 10.0.3 && < 13.0.0)，but version Newtonsoft.Json 13.0.1 was resolved.`	
`Warning NU1608 Detected package version outside of dependency constraint: Nethereum.RPC 3.8.0 requires Newtonsoft.Json (>= 10.0.3 && < 13.0.0)，but version Newtonsoft.Json 13.0.1 was resolved.`	
`Warning NU1608 Detected package version outside of dependency constraint: Nethereum.Signer 3.8.0 requires Newtonsoft.Json (>= 10.0.3 && < 13.0.0)，but version Newtonsoft.Json 13.0.1 was resolved.`	
`Warning NU1608 Detected package version outside of dependency constraint: Nethereum.Util 3.8.0 requires Newtonsoft.Json (>= 10.0.3 && < 13.0.0)，but version Newtonsoft.Json 13.0.1 was resolved.`	
`Warning NU1608 Detected package version outside of dependency constraint: Nethereum.JsonRpc.Client 3.8.0 requires Newtonsoft.Json (>= 10.0.3 && < 13.0.0)，but version Newtonsoft.Json 13.0.1 was resolved.`	
`Warning NU1608 Detected package version outside of dependency constraint: Nethereum.Model 3.8.0 requires Newtonsoft.Json (>= 10.0.3 && < 13.0.0)，but version Newtonsoft.Json 13.0.1 was resolved.`	
`Warning NU1608 Detected package version outside of dependency constraint: Nethereum.RLP 3.8.0 requires Newtonsoft.Json (>= 10.0.3 && < 13.0.0)，but version Newtonsoft.Json 13.0.1 was resolved.`	


This fix can remove this warnings from EthInclude's dependency graph.
Hope the PR can help you.

Best regards,
sucrose